### PR TITLE
Fix: missed end-of-video pause when autoplayUpNext fires before video ends

### DIFF
--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -156,7 +156,6 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
         elif event_type == "autoplayUpNext":
             create_task(self.set_auto_play_mode(self.auto_play))
             self._autoplay_pending = not self.auto_play
-            self._video_duration = 0.0  # reset so _reschedule_end_pause waits for onStateChange
             self._reschedule_end_pause()
             if len(args) > 0 and (vid_id := args[0]["videoId"]):  # if video id is not empty
                 self.logger.info(f"Getting segments for next video: {vid_id}")
@@ -220,6 +219,9 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
             return
         elapsed = asyncio.get_event_loop().time() - self._video_start_wall
         current_pos = self._video_start_pos + elapsed
+        if current_pos > self._video_duration:
+            # Timing data is stale (e.g. _video_start_wall never set) or video already ended
+            return
         pause_in = self._video_duration - current_pos - 0.5  # pause 0.5s before end
         if pause_in < 0:
             pause_in = 0.1


### PR DESCRIPTION
## Summary

- Removes the `_video_duration = 0.0` reset in `autoplayUpNext` that was cancelling the scheduled end-of-video pause and leaving no replacement task, causing the video to auto-advance without pausing when `auto_play=false`
- Adds a stale-data guard in `_reschedule_end_pause`: if `current_pos > _video_duration`, the timing data is invalid (typically `_video_start_wall` was never initialized by an `onStateChange` event) so we skip scheduling rather than firing an immediate spurious pause

## Root Cause

`16041e5` fixed an immediate-pause bug on the next video by resetting `_video_duration = 0` in `autoplayUpNext`. However, this also cancelled the existing pause task for the *current* video and prevented rescheduling (due to the `_video_duration <= 0` early return). When a video plays smoothly end-to-end with no state changes after `autoplayUpNext`, no new pause task is ever created and the video auto-advances.

The original immediate-pause bug was caused by `_video_start_wall` being `0.0` (never set), making `elapsed` huge and `current_pos >> video_duration`, triggering `pause_in = 0.1`. The new guard in `_reschedule_end_pause` catches this directly without discarding the valid duration.

## Test plan

- [ ] Watch a video with `auto_play=false` — it should pause near the end instead of advancing to the next video
- [ ] Verify the next video does not get an immediate spurious pause when it starts
- [ ] Test a video that plays smoothly end-to-end (no seeks after the initial `onStateChange`) to confirm the pause fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)