### PR TITLE
Fix: debug env var and missed pause resilience after reconnect

### DIFF
--- a/src/iSponsorBlockTV/helpers.py
+++ b/src/iSponsorBlockTV/helpers.py
@@ -131,7 +131,7 @@ class Config:
     default=lambda: os.getenv("iSPBTV_data_dir") or user_data_dir("iSponsorBlockTV", "dmunozv04"),
     help="data directory",
 )
-@click.option("--debug", is_flag=True, help="debug mode")
+@click.option("--debug", is_flag=True, envvar="iSPBTV_debug", help="debug mode")
 @click.option("--http-tracing", is_flag=True, help="Enable HTTP request/response tracing")
 # legacy commands as arguments
 @click.option("--setup", is_flag=True, help="Setup the program graphically", hidden=True)

--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -124,6 +124,11 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
                     self._video_duration = duration
                     self._video_start_wall = asyncio.get_event_loop().time()
                     self._video_start_pos = current_time
+                    # If auto_play is off but we're past 90% without a pending pause,
+                    # we likely missed the autoplayUpNext event (e.g. during a reconnect)
+                    if not self.auto_play and not self._autoplay_pending and current_time > duration * 0.9:
+                        self.logger.info("Missed autoplayUpNext detected, scheduling end pause")
+                        self._autoplay_pending = True
                     self._reschedule_end_pause()
             # Unmute when the video starts playing
             if self.mute_ads and data["state"] == "1":


### PR DESCRIPTION
## Summary

- Adds `iSPBTV_debug=true` environment variable support for debug logging — no rebuild needed to enable it in Docker
- Detects missed `autoplayUpNext` events caused by the YouTube Lounge connection dropping every ~4-5 minutes (server-side HTTP long-poll close): if `auto_play=false`, we're past 90% of the video, and no end-pause is pending, we treat it as a missed event and schedule the pause

## Root cause of reconnect issue

The YouTube Lounge API uses HTTP long-polling. YouTube closes the connection server-side every ~4-5 minutes (status 200). iSponsorBlockTV reconnects automatically, but if `autoplayUpNext` fires during the brief gap, it's never received and `_autoplay_pending` stays False — the video auto-advances without pausing.

## How to enable debug logging

Add `iSPBTV_debug=true` to your container's environment variables in Portainer (or docker-compose). This will log all events including `autoplayUpNext`, `onStateChange` with duration, and pause scheduling decisions.

## Test plan

- [ ] Set `iSPBTV_debug=true` and verify DEBUG-level events appear in container logs
- [ ] Watch a video with `auto_play=false` past the 90% mark after a reconnect and verify it still pauses
- [ ] Verify normal (non-reconnect) pause behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)