### PR TITLE
Add log line when end-of-video pause fires

### DIFF
--- a/src/iSponsorBlockTV/ytlounge.py
+++ b/src/iSponsorBlockTV/ytlounge.py
@@ -235,6 +235,7 @@ class YtLoungeApi(pyytlounge.YtLoungeApi):
             await asyncio.sleep(pause_in)
             if self._autoplay_pending:
                 self._autoplay_pending = False
+                self.logger.info("Pausing at end of video to prevent autoplay")
                 await self.pause()
 
         self._end_pause_task = create_task(_pause_at_end())


### PR DESCRIPTION
Adds an INFO log line when the end-of-video pause is sent to the device, so we can confirm in logs whether the pause is actually firing vs. being silently skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)