### PR TITLE
feat: trigger Portainer redeploy via webhook after main branch image push

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -150,3 +150,11 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ghcr.io/${{ env.REPO_LC }}:${{ steps.meta.outputs.version }}
+
+      - name: Trigger Portainer redeploy
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        run: |
+          curl -s -o /dev/null -w "%{http_code}" -X POST \
+            -H "${{ secrets.CF_ACCESS_CLIENT_ID }}" \
+            -H "${{ secrets.CF_ACCESS_CLIENT_SECRET }}" \
+            "${{ secrets.PORTAINER_WEBHOOK_URL }}"


### PR DESCRIPTION
## Summary
- Adds a final step in the `merge` job that POSTs to Portainer's stack webhook after the manifest is pushed to GHCR
- Only fires on pushes to the default branch (not PRs, tags, or other branches)
- Uses Cloudflare Access headers (`CF_ACCESS_CLIENT_ID`, `CF_ACCESS_CLIENT_SECRET`) to authenticate through the CF tunnel
- Requires three GitHub secrets: `CF_ACCESS_CLIENT_ID`, `CF_ACCESS_CLIENT_SECRET`, `PORTAINER_WEBHOOK_URL`

## After merging
- Enable the stack webhook in Portainer for the iSponsorBlockTV stack (Stack → Edit → Webhooks) and ensure the URL matches `PORTAINER_WEBHOOK_URL`
- Watchtower can be removed from `noctorg/proxmox-docker` docker-compose.yml

## Test plan
- [ ] Merge a change to `main` and verify the `Trigger Portainer redeploy` step succeeds (HTTP 200)
- [ ] Confirm Portainer pulls the new image and redeploys the stack automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)