### PR TITLE
chore: remove Portainer redeploy webhook step

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -150,11 +150,3 @@ jobs:
       - name: Inspect image
         run: |
           docker buildx imagetools inspect ghcr.io/${{ env.REPO_LC }}:${{ steps.meta.outputs.version }}
-
-      - name: Trigger Portainer redeploy
-        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        run: |
-          curl -s -o /dev/null -w "%{http_code}" -X POST \
-            -H "${{ secrets.CF_ACCESS_CLIENT_ID }}" \
-            -H "${{ secrets.CF_ACCESS_CLIENT_SECRET }}" \
-            "${{ secrets.PORTAINER_WEBHOOK_URL }}"


### PR DESCRIPTION
## Summary
- Removes the `Trigger Portainer redeploy` step from the `merge` job in `build_docker_images.yml`

## Context
Migrating from Portainer to Komodo for container management. Komodo handles image auto-updates via native GHCR polling, making the post-push webhook call to Portainer redundant.

## After merging
- Remove the `CF_ACCESS_CLIENT_ID`, `CF_ACCESS_CLIENT_SECRET`, and `PORTAINER_WEBHOOK_URL` secrets from this repo's settings (once Portainer is fully decommissioned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)