### PR TITLE
fix: pause when segment skip reaches end of video

### DIFF
--- a/src/iSponsorBlockTV/main.py
+++ b/src/iSponsorBlockTV/main.py
@@ -119,10 +119,19 @@ class DeviceListener:
     async def skip(self, time_to, position, uuids):
         await asyncio.sleep(time_to)
         self.logger.info("Skipping segment: seeking to %s", position)
+        lc = self.lounge_controller
         await asyncio.gather(
-            asyncio.create_task(self.lounge_controller.seek_to(position)),
+            asyncio.create_task(lc.seek_to(position)),
             asyncio.create_task(self.api_helper.mark_viewed_segments(uuids)),
         )
+        if (
+            not lc.auto_play
+            and lc._video_duration > 0
+            and position >= lc._video_duration - 1
+        ):
+            self.logger.info("Segment skip reached end of video, pausing to prevent autoplay")
+            lc._autoplay_pending = False
+            await lc.pause()
 
     async def cancel(self):
         self.cancelled = True


### PR DESCRIPTION
## Root cause

When a SponsorBlock segment ends at or within 1 second of the video's duration, \`skip()\` seeks to that position and YouTube immediately autoplays the next video. The time-based end-of-video pause (scheduled by \`autoplayUpNext\`) gets cancelled within ~1s when the new video's \`onStateChange\` fires and calls \`_reschedule_end_pause()\` with the new video's duration — so the pause never fires.

Observed in logs: at 22:50:42 on 2026-03-02, seeking to 737.781 (= video duration of \`obPYtjz8IrU\`) caused an immediate transition to the next video with no pause.

## Fix

After the seek in \`skip()\`, if \`auto_play\` is disabled and the seek target is within 1 second of the video's end, immediately send a pause command and clear \`_autoplay_pending\` to prevent a duplicate pause from the timer.

## Test plan
- [ ] Play a video where a sponsor segment ends at or near the end of the video
- [ ] Verify playback pauses after the segment skip instead of autoplaying the next video
- [ ] Verify normal mid-video segment skips are unaffected
- [ ] Verify behavior is unchanged when \`auto_play\` is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)