### PR TITLE
Refresh container base and aiohttp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.13-alpine3.22 AS base
+FROM python:3.13.14-alpine AS base
 
 RUN apk upgrade --no-cache
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.13.5
+aiohttp==3.14.1
 appdirs==1.4.4
 async-cache==1.1.1
 pyytlounge==2.3.0


### PR DESCRIPTION
Update the Docker base image to Python 3.13.14 on current Alpine and bump aiohttp to 3.14.1.\n\nVerified by building the image on the Docker host and scanning it with Trivy for high/critical fixed vulnerabilities.