### PR TITLE
Remove unused QEMU setup

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -56,9 +56,6 @@ jobs:
             type=ref,event=branch
             type=schedule
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 


### PR DESCRIPTION
## Summary
- remove docker/setup-qemu-action from the Docker image workflow
- keep the workflow amd64-only, matching the only published platform
- avoid noisy setup-qemu cache reservation annotations

## Verification
- Parsed workflow YAML locally
- Checked the workflow no longer references QEMU or ARM platforms